### PR TITLE
fix 2 RefResolver bugs, 'id', and '$ref' properties handled as they a…

### DIFF
--- a/fastjsonschema/ref_resolver.py
+++ b/fastjsonschema/ref_resolver.py
@@ -162,12 +162,12 @@ class RefResolver(object):
 
     def walk(self, node: dict):
         """
-        Walk thru schema and Normalize ``id`` and ``$ref`` instances
+        Walk thru schema and dereferencing ``id`` and ``$ref`` instances
         """
-        if '$ref' in node:
+        if '$ref' in node and isinstance(node['$ref'], str):
             ref = node['$ref']
             node['$ref'] = urlparse.urljoin(self.resolution_scope, ref)
-        if 'id' in node:
+        elif 'id' in node and isinstance(node['id'], str):
             id = node['id']
             with self.in_scope(id):
                 self.store[normalize(self.resolution_scope)] = node

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -148,7 +148,7 @@ def test_object_with_id_property(asserter, value, expected):
     ({'$ref': 1}, JsonSchemaException('data.$ref must be string')),
 ])
 
-def test_object_with_id_property(asserter, value, expected):
+def test_object_with_ref_property(asserter, value, expected):
     asserter({
         "type": "object",
         "properties": {

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -129,3 +129,29 @@ def test_pattern_properties(asserter, value, expected):
         },
         'additionalProperties': False,
     }, value, expected)
+
+@pytest.mark.parametrize('value, expected', [
+    ({'id': 1}, {'id': 1}),
+    ({'id': 'a'}, JsonSchemaException('data.id must be integer')),
+])
+
+def test_object_with_id_property(asserter, value, expected):
+    asserter({
+        "type": "object",
+        "properties": {
+            "id": {"type": "integer"}
+        }
+    }, value, expected)
+
+@pytest.mark.parametrize('value, expected', [
+    ({'$ref': 'ref://to.somewhere'}, {'$ref': 'ref://to.somewhere'}),
+    ({'$ref': 1}, JsonSchemaException('data.$ref must be string')),
+])
+
+def test_object_with_id_property(asserter, value, expected):
+    asserter({
+        "type": "object",
+        "properties": {
+            "$ref": {"type": "string"}
+        }
+    }, value, expected)


### PR DESCRIPTION
fix 2 RefResolver bugs, 'id', and '$ref' properties handled as they are actual schema 'id' and '$ref'.
fix for #12 